### PR TITLE
declare global Env type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,12 @@
 export type Handler = (c: C) => Response | Promise<Response>
 
+declare global {
+  interface Env {}
+}
+
 export type C = {
   req: Request
-  env: {}
+  env: Env
   executionContext: ExecutionContext
   result: URLPatternURLPatternResult
 }
@@ -15,7 +19,7 @@ export type Route = {
 
 export type Fetch = (
   req: Request,
-  env?: {},
+  env?: Env,
   executionContext?: ExecutionContext
 ) => Response | Promise<Response>
 


### PR DESCRIPTION
Currently, the wrangler create project comes with a `worker-configuration.d.ts` file by default.
I added a global namespace Env type for Pico so that it can be merged with the user's local Env and provide type awareness in the env parameter.

```tsx
interface Env {
	// Example binding to KV. Learn more at https://developers.cloudflare.com/workers/runtime-apis/kv/
	// MY_KV_NAMESPACE: KVNamespace;
	//
	// Example binding to Durable Object. Learn more at https://developers.cloudflare.com/workers/runtime-apis/durable-objects/
	// MY_DURABLE_OBJECT: DurableObjectNamespace;
	//
	// Example binding to R2. Learn more at https://developers.cloudflare.com/workers/runtime-apis/r2/
	// MY_BUCKET: R2Bucket;
	//
	// Example binding to a Service. Learn more at https://developers.cloudflare.com/workers/runtime-apis/service-bindings/
	// MY_SERVICE: Fetcher;
	//
	// Example binding to a Queue. Learn more at https://developers.cloudflare.com/queues/javascript-apis/
	// MY_QUEUE: Queue;
	API_KEY: string
	SEB: SendEmail
}
```

<img width="602" alt="image" src="https://github.com/yusukebe/pico/assets/1720349/8fdf86d0-bb2d-4639-aca9-5736bdc78b1c">
